### PR TITLE
docs: Add MCP tools reference and GitHub CLI guidance

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -112,6 +112,7 @@ When working on this project, always follow these Docker-related practices:
 6. Update documentation as needed
 7. Verify changes against the risk management plan
 8. Track progress in rebuild_plan/progress_tracking.md
+9. Use GitHub CLI for all repository operations (see docs/github_cli_guide.md)
 
 ## Git Workflow
 Follow the standardized Git workflow outlined in rebuild_plan/git_workflow.md:

--- a/.cursorrules
+++ b/.cursorrules
@@ -121,22 +121,33 @@ Follow the standardized Git workflow outlined in rebuild_plan/git_workflow.md:
    - Name branches according to the pattern: feature/<feature-name>, bugfix/<bug-description>, etc.
    - Keep branches focused on single features or fixes
 
-2. **Commit Standards**:
+2. **Preferred Git Tools**:
+   - Use GitHub CLI (`gh`) or MCP GitHub functions instead of direct Git commands
+   - For CLI operations, use `gh` commands (see docs/github_cli_guide.md)
+   - For AI-assisted workflows, use MCP GitHub functions when available
+
+3. **Commit Standards**:
    - Write descriptive commit messages with prefixes (feat:, fix:, docs:, etc.)
    - Keep the first line under 50 characters
    - Add detailed descriptions for complex changes
 
-3. **Code Review Process**:
-   - Create Pull Requests to the develop branch
+4. **Code Review Process**:
+   - Create Pull Requests to the develop branch using GitHub CLI:
+     ```bash
+     gh pr create --base develop --title "feat: Brief description" --body "Detailed description"
+     ```
    - Ensure all tests pass before requesting review
    - Address review comments with additional commits
 
-4. **Merging**:
-   - Use non-fast-forward merges (--no-ff) to maintain a clear history
+5. **Merging**:
+   - Use non-fast-forward merges to maintain a clear history:
+     ```bash
+     gh pr merge --merge --delete-branch
+     ```
    - Merge to main only through release branches or hotfixes
    - Tag all production releases with version numbers
 
-For detailed information, refer to rebuild_plan/git_workflow.md.
+For detailed information, refer to rebuild_plan/git_workflow.md and docs/github_cli_guide.md.
 
 ## Import Guidelines
 - Import GTK modules first, then standard library, then app modules

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# Default owners for everything in the repo
+* @jdamboeck
+
+# Documentation owners
+docs/ @jdamboeck
+rebuild_plan/ @jdamboeck
+
+# Core code owners
+preview_maker/core/ @jdamboeck
+
+# UI code owners
+preview_maker/ui/ @jdamboeck
+
+# AI integration code owners
+preview_maker/ai/ @jdamboeck
+
+# Testing code owners
+tests/ @jdamboeck

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,49 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "bug: "
+labels: bug
+assignees: ""
+---
+
+## Bug Description
+<!-- A clear and concise description of what the bug is -->
+
+## Steps to Reproduce
+<!-- Steps to reproduce the behavior -->
+1.
+2.
+3.
+4.
+
+## Expected Behavior
+<!-- A clear and concise description of what you expected to happen -->
+
+## Actual Behavior
+<!-- A clear and concise description of what actually happened -->
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your problem -->
+
+## Environment
+<!-- Please complete the following information -->
+- OS: [e.g. Ubuntu 22.04]
+- Docker Version: [e.g. 24.0.5]
+- Python Version: [e.g. 3.10]
+- GTK Version: [e.g. 4.0]
+
+## Additional Context
+<!-- Add any other context about the problem here -->
+
+## GitHub CLI Reference
+<!-- For maintainers and contributors (not to be included in the final issue) -->
+<!--
+# Create an issue using GitHub CLI:
+gh issue create --title "bug: [Brief description]" --body "[Detailed description]" --label bug
+
+# Add assignee:
+gh issue edit [number] --add-assignee [username]
+
+# Add additional labels:
+gh issue edit [number] --add-label "priority-high,needs-triage"
+-->

--- a/.github/ISSUE_TEMPLATE/documentation_update.md
+++ b/.github/ISSUE_TEMPLATE/documentation_update.md
@@ -1,0 +1,38 @@
+---
+name: Documentation Update
+about: Suggest improvements or corrections to documentation
+title: "docs: "
+labels: documentation
+assignees: ""
+---
+
+## Documentation Issue
+<!-- Describe what's missing, unclear, or incorrect in the current documentation -->
+
+## Affected Documentation
+<!-- Specify which documentation needs updating (file paths, URLs, etc.) -->
+
+## Proposed Changes
+<!-- Describe the changes you propose or the information that should be added -->
+
+## Additional Context
+<!-- Add any other context or screenshots about the documentation update here -->
+
+## Expected Benefits
+<!-- Describe how these documentation changes will help users or developers -->
+
+## GitHub CLI Reference
+<!-- For maintainers and contributors (not to be included in the final issue) -->
+<!--
+# Create a documentation issue using GitHub CLI:
+gh issue create --title "docs: [Brief description]" --body "[Detailed description]" --label documentation
+
+# Add assignee:
+gh issue edit [number] --add-assignee [username]
+
+# Create a branch for updating documentation:
+gh issue develop [issue-number] -b docs/[description]
+
+# Submit the PR when complete:
+gh pr create --base develop --title "docs: [Brief description]" --body "Closes #[issue-number]"
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,44 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "feat: "
+labels: enhancement
+assignees: ""
+---
+
+## Feature Description
+<!-- A clear and concise description of the feature you're requesting -->
+
+## Problem Statement
+<!-- Describe the problem this feature would solve or the need it addresses -->
+
+## Proposed Solution
+<!-- Describe the solution you'd like to see implemented -->
+
+## Alternative Solutions
+<!-- Describe any alternative solutions or features you've considered -->
+
+## Implementation Details
+<!-- If you can provide any technical details about the implementation, please do so here -->
+
+## Mockups / Examples
+<!-- If applicable, add mockups or examples from other projects to help explain your feature request -->
+
+## Additional Context
+<!-- Add any other context about the feature request here -->
+
+## GitHub CLI Reference
+<!-- For maintainers and contributors (not to be included in the final issue) -->
+<!--
+# Create a feature request using GitHub CLI:
+gh issue create --title "feat: [Feature name]" --body "[Detailed description]" --label enhancement
+
+# Add assignee:
+gh issue edit [number] --add-assignee [username]
+
+# Add additional labels:
+gh issue edit [number] --add-label "good-first-issue,help-wanted"
+
+# Create a branch for implementing the feature:
+gh issue develop [issue-number] -b feature/[feature-name]
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+# Pull Request
+
+## Description
+<!-- Provide a concise description of the changes introduced by this PR -->
+
+## Related Issue
+<!-- Link to the issue this PR addresses using the syntax: Closes #123 -->
+
+## Type of Change
+<!-- Mark the appropriate option with an [x] -->
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI/CD changes
+
+## Testing
+<!-- Mark the testing completed with an [x] -->
+- [ ] Unit tests pass
+- [ ] Integration tests pass
+- [ ] Docker tests pass
+- [ ] UI tests pass in headless environment
+
+## Screenshots
+<!-- If applicable, add screenshots to help explain your changes -->
+
+## Checklist
+<!-- Mark all completed items with an [x] -->
+- [ ] My code follows the project's code style guidelines
+- [ ] I have updated the documentation accordingly
+- [ ] I have added tests that prove my fix/feature works
+- [ ] All new and existing tests pass
+- [ ] I have verified my changes in the Docker environment
+- [ ] I have updated progress_tracking.md (if applicable)
+
+## GitHub CLI Usage
+<!-- These commands are for reference, not to be included in the final PR -->
+<!--
+# Creating this PR using GitHub CLI (for reference):
+gh pr create --base develop --title "feat: Add [feature name]" --body "Implements [brief description]"
+
+# Checking PR status:
+gh pr view
+
+# Checking PR checks:
+gh pr checks
+
+# Getting PR suggestions:
+gh pr view --comments
+-->

--- a/docs/ai_agent_git_workflow.md
+++ b/docs/ai_agent_git_workflow.md
@@ -1,0 +1,301 @@
+# AI Agent Integration with Git Workflow
+
+This document provides guidelines for integrating AI agents with the Preview Maker Git workflow, ensuring consistent and standardized contributions.
+
+## Overview
+
+AI agents, such as Claude or other AI assistants, can help with the Preview Maker project in various ways, including code generation, documentation updates, and issue resolution. This guide ensures that AI agent contributions follow the project's Git workflow and maintain code quality standards.
+
+## GitHub MCP Functions for AI Agents
+
+When working with AI assistants that support MCP functions, prefer these over direct Git commands for GitHub operations:
+
+```javascript
+// Create a pull request
+mcp_github_create_pull_request({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  title: "feat: Add new feature",
+  body: "Implements...\n\nCloses #123",
+  head: "feature/my-feature",
+  base: "develop"
+});
+
+// Create or update a file
+mcp_github_create_or_update_file({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  path: "path/to/file.md",
+  content: "File content here",
+  message: "docs: Update documentation",
+  branch: "feature/my-feature"
+});
+
+// Create an issue
+mcp_github_create_issue({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  title: "bug: Something is broken",
+  body: "When I do X, Y happens instead of Z",
+  labels: ["bug", "priority-high"]
+});
+```
+
+## AI Agent Workflow Patterns
+
+### Feature Development
+
+1. **Branch Creation**:
+   ```javascript
+   // Create feature branch from develop
+   mcp_github_create_branch({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     branch: "feature/ai-generated-feature",
+     from_branch: "develop"
+   });
+   ```
+
+2. **Code Implementation**:
+   ```javascript
+   // Add or update files
+   mcp_github_create_or_update_file({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     path: "path/to/new/file.py",
+     content: "# Generated code\n...",
+     message: "feat: Implement feature X",
+     branch: "feature/ai-generated-feature"
+   });
+   ```
+
+3. **Pull Request Creation**:
+   ```javascript
+   // Create PR
+   mcp_github_create_pull_request({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     title: "feat: Implement feature X",
+     body: "This PR adds feature X, which...\n\nCloses #123",
+     head: "feature/ai-generated-feature",
+     base: "develop"
+   });
+   ```
+
+### Documentation Updates
+
+1. **Branch Creation**:
+   ```javascript
+   // Create documentation branch
+   mcp_github_create_branch({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     branch: "docs/update-readme",
+     from_branch: "develop"
+   });
+   ```
+
+2. **Documentation Changes**:
+   ```javascript
+   // Update documentation file
+   mcp_github_create_or_update_file({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     path: "README.md",
+     content: "# Updated content\n...",
+     message: "docs: Improve README clarity",
+     branch: "docs/update-readme"
+   });
+   ```
+
+3. **Pull Request Creation**:
+   ```javascript
+   // Create PR for documentation update
+   mcp_github_create_pull_request({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     title: "docs: Update README",
+     body: "This PR improves the README by...\n\nCloses #456",
+     head: "docs/update-readme",
+     base: "develop"
+   });
+   ```
+
+### Bug Fixes
+
+1. **Branch Creation**:
+   ```javascript
+   // Create bugfix branch
+   mcp_github_create_branch({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     branch: "bugfix/fix-issue-789",
+     from_branch: "develop"
+   });
+   ```
+
+2. **Code Fixes**:
+   ```javascript
+   // Update file with fix
+   mcp_github_create_or_update_file({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     path: "path/to/buggy/file.py",
+     content: "# Fixed code\n...",
+     message: "fix: Resolve issue with X",
+     branch: "bugfix/fix-issue-789"
+   });
+   ```
+
+3. **Pull Request Creation**:
+   ```javascript
+   // Create PR for bug fix
+   mcp_github_create_pull_request({
+     owner: "jdamboeck",
+     repo: "preview-maker",
+     title: "fix: Resolve issue with X",
+     body: "This PR fixes issue #789 by...\n\nFixes #789",
+     head: "bugfix/fix-issue-789",
+     base: "develop"
+   });
+   ```
+
+## Commit Message Guidelines for AI Agents
+
+AI agents should follow the same commit message standards as human contributors:
+
+1. **Use the correct prefix**:
+   - `feat:` - New feature
+   - `fix:` - Bug fix
+   - `docs:` - Documentation changes
+   - `style:` - Formatting changes
+   - `refactor:` - Code refactoring without functional changes
+   - `test:` - Adding or updating tests
+   - `chore:` - Maintenance tasks
+
+2. **Keep the first line concise** (under 50 characters)
+
+3. **Provide a detailed description** for complex changes
+
+Example:
+```
+feat: Add circular mask generation
+
+- Implements algorithm for creating circular masks with configurable radius
+- Optimizes performance for large images using caching
+- Adds type hints and comprehensive documentation
+```
+
+## Code Style Compliance
+
+AI agents must follow the project's code style guidelines:
+
+1. **Follow PEP 8** for Python code
+2. **Use type annotations** throughout
+3. **Include docstrings** for all classes and functions
+4. **Follow the import guidelines** (GTK first, then standard library, then app modules)
+5. **Use spaces, not tabs** for indentation (4 spaces for Python)
+
+## Testing Requirements for AI-Generated Code
+
+All code generated by AI agents must include appropriate tests:
+
+1. **Unit tests** for specific functions and methods
+2. **Integration tests** for component interactions
+3. **UI tests** for user interface components, including headless test mode
+4. **Ensure tests run in Docker** environment
+
+Example:
+```python
+def test_circular_mask_generation():
+    """Test that the circular mask generator works correctly."""
+    processor = ImageProcessor()
+    mask = processor.generate_circular_mask(radius=50)
+
+    # Assert mask has correct dimensions
+    assert mask.size == (100, 100)
+
+    # Assert mask is circular
+    center = mask.size[0] // 2
+    assert mask.getpixel((center, center)) == 255  # Center is white
+    assert mask.getpixel((0, 0)) == 0  # Corner is black
+```
+
+## Documentation Requirements
+
+AI agents should update or create documentation when:
+
+1. **Adding new functionality**
+2. **Changing existing behavior**
+3. **Updating dependencies**
+4. **Fixing bugs with user-visible impact**
+
+Documentation should include:
+- Purpose and usage examples
+- Parameter descriptions
+- Return value explanations
+- Exception cases
+
+## Interaction with Human Reviewers
+
+When a human reviews AI-generated PRs:
+
+1. **Respond to feedback** by creating additional commits addressing the feedback
+2. **Explain reasoning** behind implementation choices when asked
+3. **Suggest alternatives** if the initial approach has issues
+
+## Monitoring and Tracking
+
+AI agents should track their contributions to the project:
+
+1. **Maintain a list of created issues**
+2. **Track open pull requests**
+3. **Follow up on feedback** and review comments
+
+## AI Agent Responsibility Boundaries
+
+AI agents should:
+
+1. **NOT modify protected branches** directly (main, develop)
+2. **NOT modify critical infrastructure** without human review
+3. **NOT modify deployment configurations** without explicit approval
+4. **NOT create releases** (human approval required)
+
+## Best Practices for AI-Human Collaboration
+
+1. **Clearly label AI contributions** in commit messages or PR descriptions
+2. **Document complex logic** with comments explaining the reasoning
+3. **Prefer multiple small, focused PRs** over large, monolithic changes
+4. **Link PRs to issues** they address
+
+## Troubleshooting Common Issues
+
+### API Rate Limiting
+
+If encountering API rate limits:
+- Implement exponential backoff between requests
+- Batch changes to minimize API calls
+- Use conditional requests where appropriate
+
+### Branch Conflicts
+
+When merge conflicts occur:
+1. Fetch latest changes from target branch
+2. Resolve conflicts locally
+3. Push updated branch
+4. Update the PR
+
+### Permission Issues
+
+If lacking permissions for specific operations:
+1. Document the intended changes
+2. Request assistance from a repository administrator
+
+## Conclusion
+
+Following these guidelines ensures that AI agents contribute effectively to the Preview Maker project while maintaining code quality standards and adhering to the established Git workflow.
+
+For additional details, refer to:
+- [GitHub CLI Guide](github_cli_guide.md)
+- [Git Workflow](../rebuild_plan/git_workflow.md)
+- [Branch Protection Rules](branch_protection_rules.md)

--- a/docs/branch_protection_rules.md
+++ b/docs/branch_protection_rules.md
@@ -1,0 +1,174 @@
+# Branch Protection Rules for Preview Maker
+
+This document outlines the branch protection rules implemented for the Preview Maker repository to ensure code quality and maintain a stable codebase.
+
+## Protected Branches
+
+The following branches are protected:
+
+- **main**: Production-ready code
+- **develop**: Integration branch for feature development
+
+## Protection Rules
+
+### For `main` Branch
+
+1. **Require Pull Request Reviews**
+   - At least 1 approval required before merging
+   - Dismiss stale pull request approvals when new commits are pushed
+   - Require review from Code Owners (defined in `.github/CODEOWNERS`)
+
+2. **Require Status Checks to Pass**
+   - Required checks:
+     - Unit tests
+     - Integration tests
+     - Docker tests
+     - UI tests (headless)
+     - Code quality (linting)
+   - Require branches to be up to date before merging
+
+3. **Merge Restrictions**
+   - No direct commits to `main` (all changes must come through pull requests)
+   - No force pushes allowed
+   - No deletion of the branch
+
+4. **Include Administrators**
+   - These restrictions apply to everyone, including repository administrators
+
+### For `develop` Branch
+
+1. **Require Pull Request Reviews**
+   - At least 1 approval required before merging
+   - Dismiss stale pull request approvals when new commits are pushed
+
+2. **Require Status Checks to Pass**
+   - Required checks:
+     - Unit tests
+     - Integration tests
+     - Docker tests
+     - UI tests (headless)
+     - Code quality (linting)
+   - Require branches to be up to date before merging
+
+3. **Merge Restrictions**
+   - No direct commits to `develop` (all changes must come through pull requests)
+   - No force pushes allowed
+   - No deletion of the branch
+
+## Implementation with GitHub CLI
+
+Branch protection rules can be applied using GitHub CLI:
+
+```bash
+# For main branch
+gh api repos/jdamboeck/preview-maker/branches/main/protection \
+  --method PUT \
+  -f required_status_checks.strict=true \
+  -f required_status_checks.contexts='["unit-tests", "integration-tests", "docker-tests", "ui-tests", "linting"]' \
+  -f enforce_admins=true \
+  -f required_pull_request_reviews.required_approving_review_count=1 \
+  -f required_pull_request_reviews.dismiss_stale_reviews=true \
+  -f required_pull_request_reviews.require_code_owner_reviews=true \
+  -f restrictions=null
+
+# For develop branch
+gh api repos/jdamboeck/preview-maker/branches/develop/protection \
+  --method PUT \
+  -f required_status_checks.strict=true \
+  -f required_status_checks.contexts='["unit-tests", "integration-tests", "docker-tests", "ui-tests", "linting"]' \
+  -f enforce_admins=true \
+  -f required_pull_request_reviews.required_approving_review_count=1 \
+  -f required_pull_request_reviews.dismiss_stale_reviews=true \
+  -f restrictions=null
+```
+
+## MCP Function Implementation
+
+For systems with MCP functions, branch protection can be applied programmatically (note: this is a conceptual example as direct MCP functions for branch protection may not be available):
+
+```javascript
+// Conceptual example - actual implementation would use GitHub API directly
+function setBranchProtection(branch, settings) {
+  const url = `https://api.github.com/repos/jdamboeck/preview-maker/branches/${branch}/protection`;
+
+  // Would need to use an HTTP request function or GitHub API wrapper
+  // This is a placeholder for the concept
+  console.log(`Setting protection for ${branch} with settings:`, settings);
+}
+
+// Main branch protection
+setBranchProtection("main", {
+  required_status_checks: {
+    strict: true,
+    contexts: ["unit-tests", "integration-tests", "docker-tests", "ui-tests", "linting"]
+  },
+  enforce_admins: true,
+  required_pull_request_reviews: {
+    required_approving_review_count: 1,
+    dismiss_stale_reviews: true,
+    require_code_owner_reviews: true
+  },
+  restrictions: null
+});
+
+// Develop branch protection
+setBranchProtection("develop", {
+  required_status_checks: {
+    strict: true,
+    contexts: ["unit-tests", "integration-tests", "docker-tests", "ui-tests", "linting"]
+  },
+  enforce_admins: true,
+  required_pull_request_reviews: {
+    required_approving_review_count: 1,
+    dismiss_stale_reviews: true
+  },
+  restrictions: null
+});
+```
+
+## Verification
+
+To verify that branch protection rules are correctly applied, use:
+
+```bash
+gh api repos/jdamboeck/preview-maker/branches/main/protection | jq .
+gh api repos/jdamboeck/preview-maker/branches/develop/protection | jq .
+```
+
+## Code Owners Definition
+
+Code owners are defined in the `.github/CODEOWNERS` file and determine who must review changes to specific files:
+
+```
+# Example CODEOWNERS file
+# Global owners for the entire repository
+*       @jdamboeck
+
+# Core infrastructure owners
+/preview_maker/core/  @core-team-member
+
+# UI component owners
+/preview_maker/ui/    @ui-team-member
+
+# Testing infrastructure owners
+/tests/               @qa-team-member
+```
+
+## Branch Protection Exceptions
+
+In rare cases, branch protection may need to be temporarily disabled for emergency fixes. This should be documented and requires administrator access:
+
+```bash
+# Temporarily disable branch protection (EMERGENCY USE ONLY)
+gh api repos/jdamboeck/preview-maker/branches/main/protection \
+  --method DELETE
+
+# Re-enable protection after emergency fix
+# (Run the branch protection setup commands from above)
+```
+
+**Important**: Any temporary disabling of branch protection must be:
+1. Documented with justification
+2. Communicated to the team
+3. Re-enabled as soon as possible
+4. Followed by a post-mortem if applicable

--- a/docs/github_cli_guide.md
+++ b/docs/github_cli_guide.md
@@ -1,0 +1,315 @@
+# GitHub CLI Guide for Preview Maker
+
+This guide provides instructions for using GitHub CLI (`gh`) for the Preview Maker project. Using GitHub CLI is preferred over direct Git commands for better integration with GitHub workflows.
+
+## Installation
+
+### Linux
+```bash
+# Ubuntu/Debian
+sudo apt install gh
+
+# Fedora
+sudo dnf install gh
+
+# Arch Linux
+sudo pacman -S github-cli
+```
+
+### macOS
+```bash
+brew install gh
+```
+
+### Windows
+```bash
+winget install GitHub.cli
+# or
+choco install gh
+```
+
+## Authentication
+
+Before using GitHub CLI, authenticate with your GitHub account:
+
+```bash
+gh auth login
+```
+
+Follow the interactive prompts to complete authentication.
+
+## Core Workflows
+
+### Repository Setup
+
+Clone the Preview Maker repository:
+```bash
+gh repo clone jdamboeck/preview-maker
+cd preview-maker
+```
+
+### Branch Management
+
+List all branches:
+```bash
+gh api repos/jdamboeck/preview-maker/branches --jq '.[].name'
+```
+
+Create and checkout a new branch:
+```bash
+# Create feature branch from develop
+gh api repos/jdamboeck/preview-maker/git/refs -f ref="refs/heads/feature/new-feature" \
+  -f sha="$(gh api repos/jdamboeck/preview-maker/git/refs/heads/develop --jq '.object.sha')"
+
+# Checkout locally
+gh repo clone jdamboeck/preview-maker -b feature/new-feature
+# or if already cloned
+git fetch
+git checkout feature/new-feature
+```
+
+### Pull Request Workflow
+
+Create a Pull Request:
+```bash
+gh pr create --base develop --title "feat: Add circular mask generation" \
+  --body "Implements algorithm for creating circular masks with adjustable parameters."
+```
+
+List open Pull Requests:
+```bash
+gh pr list
+```
+
+Check out a Pull Request to review locally:
+```bash
+gh pr checkout 123
+```
+
+View PR details:
+```bash
+gh pr view 123
+```
+
+Check PR status (CI checks):
+```bash
+gh pr checks 123
+```
+
+Review a PR:
+```bash
+gh pr review 123 --approve --body "Looks good to me!"
+# or
+gh pr review 123 --request-changes --body "Please fix these issues..."
+```
+
+Merge an approved PR (with non-fast-forward merge):
+```bash
+gh pr merge 123 --merge --delete-branch
+```
+
+### Issue Management
+
+Create an issue:
+```bash
+gh issue create --title "bug: Overlay not rendering correctly" \
+  --body "When using dark mode, the circular overlay becomes invisible."
+```
+
+List open issues:
+```bash
+gh issue list
+```
+
+View issue details:
+```bash
+gh issue view 456
+```
+
+Create a branch to work on an issue:
+```bash
+gh issue develop 456 -b feature/fix-overlay-visibility
+```
+
+Close an issue:
+```bash
+gh issue close 456 --reason completed
+```
+
+Add labels to an issue:
+```bash
+gh issue edit 456 --add-label "priority-high,ui"
+```
+
+### Workflow Patterns
+
+#### Feature Development Workflow
+
+```bash
+# Start from develop branch
+gh api repos/jdamboeck/preview-maker/git/refs/heads/develop --jq '.object.sha'
+gh api repos/jdamboeck/preview-maker/git/refs -f ref="refs/heads/feature/my-feature" \
+  -f sha="$(gh api repos/jdamboeck/preview-maker/git/refs/heads/develop --jq '.object.sha')"
+git fetch
+git checkout feature/my-feature
+
+# Develop your feature with regular commits (using standard git for local commits)
+# ...
+
+# Create PR when ready
+gh pr create --base develop --title "feat: Implement feature" \
+  --body "Adds new functionality for...\n\nCloses #123"
+```
+
+#### Release Workflow
+
+```bash
+# Create release branch from develop
+gh api repos/jdamboeck/preview-maker/git/refs -f ref="refs/heads/release/v1.0.0" \
+  -f sha="$(gh api repos/jdamboeck/preview-maker/git/refs/heads/develop --jq '.object.sha')"
+git fetch
+git checkout release/v1.0.0
+
+# Make final release adjustments
+# ...
+
+# Create PR to main
+gh pr create --base main --title "release: v1.0.0" \
+  --body "Release version 1.0.0"
+
+# After PR is approved and merged
+# Create the release
+gh release create v1.0.0 --title "Release v1.0.0" \
+  --notes "See CHANGELOG.md for details" --target main
+```
+
+#### Hotfix Workflow
+
+```bash
+# Create hotfix branch from main
+gh api repos/jdamboeck/preview-maker/git/refs -f ref="refs/heads/hotfix/critical-fix" \
+  -f sha="$(gh api repos/jdamboeck/preview-maker/git/refs/heads/main --jq '.object.sha')"
+git fetch
+git checkout hotfix/critical-fix
+
+# Make hotfix changes
+# ...
+
+# Create PR to main
+gh pr create --base main --title "fix: Critical production bug" \
+  --body "Fixes critical issue in production"
+
+# After PR is approved and merged
+# Create the patch release
+gh release create v1.0.1 --title "Hotfix v1.0.1" \
+  --notes "Emergency fix for..." --target main
+
+# Create PR to merge hotfix into develop
+gh pr create --base develop --head main --title "fix: Sync hotfix to develop" \
+  --body "Brings hotfix from main into develop"
+```
+
+## GitHub MCP Function Usage
+
+For systems with MCP GitHub functions available, these are preferred over direct GitHub CLI commands:
+
+```javascript
+// Create or update a file
+mcp_github_create_or_update_file({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  path: "path/to/file.md",
+  content: "File content here",
+  message: "docs: Update documentation",
+  branch: "feature/my-feature"
+});
+
+// Create a pull request
+mcp_github_create_pull_request({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  title: "feat: Add new feature",
+  body: "Implements...\n\nCloses #123",
+  head: "feature/my-feature",
+  base: "develop"
+});
+
+// Create a new issue
+mcp_github_create_issue({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  title: "bug: Something is broken",
+  body: "When I do X, Y happens instead of Z",
+  labels: ["bug", "priority-high"]
+});
+```
+
+## Environment Specific Commands
+
+### Using with Docker Development Environment
+
+When working inside the Docker environment, you can combine GitHub CLI with Docker:
+
+```bash
+# Run command in Docker environment
+docker-compose -f rebuild_plan/docker/docker-compose.yml run --rm preview-maker \
+  gh pr view 123
+```
+
+## Best Practices
+
+1. **Always pull before creating branches**:
+   ```bash
+   git pull origin develop
+   ```
+
+2. **Keep commits atomic and well-described**:
+   - Use prefix conventions: `feat:`, `fix:`, `docs:`, etc.
+   - Keep first line under 50 characters
+   - Add detailed description for complex changes
+
+3. **Reference issues in PRs and commits**:
+   - Use keywords like "Closes #123" or "Fixes #123" to automatically close issues when merged
+
+4. **Use specialized merge options**:
+   ```bash
+   gh pr merge 123 --merge --delete-branch
+   ```
+
+5. **Regularly sync with develop branch**:
+   ```bash
+   git fetch origin develop
+   git merge origin/develop
+   ```
+
+6. **Utilize PR templates**:
+   - GitHub CLI will automatically use PR templates from the repository
+
+## Troubleshooting
+
+### Authentication Issues
+```bash
+gh auth status
+gh auth refresh
+```
+
+### API Rate Limiting
+If you encounter GitHub API rate limits, consider:
+```bash
+gh auth status
+# Check if you're authenticated
+```
+
+### Common Error Resolution
+```bash
+# Force refresh local repository state
+git fetch --all
+git reset --hard origin/[your-branch-name]
+```
+
+## Further Resources
+
+- [GitHub CLI Official Documentation](https://cli.github.com/manual/)
+- [GitHub Flow Guide](https://docs.github.com/en/get-started/quickstart/github-flow)
+- [GitHub CLI API Documentation](https://cli.github.com/manual/gh_api)
+- [Preview Maker Git Workflow](../rebuild_plan/git_workflow.md)

--- a/docs/mcp_tools_reference.md
+++ b/docs/mcp_tools_reference.md
@@ -1,0 +1,191 @@
+# MCP Tools Reference
+
+This document provides a reference for all Model Control Protocol (MCP) tools available for the Preview Maker project. These tools can be used by AI assistants to interact with the development environment, GitHub repository, filesystem, and external resources.
+
+## GitHub MCP Tools
+
+These tools allow interaction with GitHub without using direct Git commands.
+
+### Repository Management
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_github_create_repository` | Create a new GitHub repository | `name`, `description`, `private` |
+| `mcp_github_fork_repository` | Fork a repository to your account | `owner`, `repo`, `organization` (optional) |
+| `mcp_github_search_repositories` | Search for GitHub repositories | `query`, `page`, `perPage` |
+
+### Branch and Commit Management
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_github_create_branch` | Create a new branch | `owner`, `repo`, `branch`, `from_branch` (optional) |
+| `mcp_github_list_commits` | List commits on a branch | `owner`, `repo`, `sha` (branch/tag), `page`, `perPage` |
+
+### File Operations
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_github_create_or_update_file` | Create or update a single file | `owner`, `repo`, `path`, `content`, `message`, `branch`, `sha` (for updates) |
+| `mcp_github_get_file_contents` | Get file or directory contents | `owner`, `repo`, `path`, `branch` (optional) |
+| `mcp_github_push_files` | Push multiple files in one commit | `owner`, `repo`, `branch`, `files` (array of path/content objects), `message` |
+
+### Issue and PR Management
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_github_create_issue` | Create a new issue | `owner`, `repo`, `title`, `body`, `labels` (optional) |
+| `mcp_github_get_issue` | Get issue details | `owner`, `repo`, `issue_number` |
+| `mcp_github_list_issues` | List repository issues | `owner`, `repo`, `state`, `labels`, `sort`, etc. |
+| `mcp_github_update_issue` | Update an existing issue | `owner`, `repo`, `issue_number`, plus fields to update |
+| `mcp_github_add_issue_comment` | Comment on an issue | `owner`, `repo`, `issue_number`, `body` |
+| `mcp_github_create_pull_request` | Create a pull request | `owner`, `repo`, `title`, `head`, `base`, `body` |
+
+### Search Operations
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_github_search_code` | Search code across repositories | `q` (query), `page`, `per_page`, etc. |
+| `mcp_github_search_issues` | Search issues and PRs | `q` (query), `sort`, `order`, etc. |
+| `mcp_github_search_users` | Search GitHub users | `q` (query), `sort`, `order`, etc. |
+
+## Docker MCP Tools
+
+These tools allow interaction with Docker containers and services.
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_docker_create_container` | Create a new Docker container | `image`, `name` (optional), `environment`, `ports` |
+| `mcp_docker_deploy_compose` | Deploy a Docker Compose stack | `compose_yaml`, `project_name` |
+| `mcp_docker_get_logs` | Get logs from a container | `container_name` |
+| `mcp_docker_list_containers` | List all Docker containers | - |
+
+## Filesystem MCP Tools
+
+These tools provide access to the filesystem within allowed directories.
+
+### Basic File Operations
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_filesystem_read_file` | Read file contents | `path` |
+| `mcp_filesystem_write_file` | Create or overwrite a file | `path`, `content` |
+| `mcp_filesystem_edit_file` | Make line-based edits to a file | `path`, `edits` (array of oldText/newText pairs), `dryRun` (optional) |
+| `mcp_filesystem_move_file` | Move or rename files | `source`, `destination` |
+| `mcp_filesystem_read_multiple_files` | Read multiple files at once | `paths` (array of paths) |
+
+### Directory Operations
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_filesystem_create_directory` | Create a directory | `path` |
+| `mcp_filesystem_list_directory` | List directory contents | `path` |
+| `mcp_filesystem_directory_tree` | Get recursive directory structure | `path` |
+| `mcp_filesystem_list_allowed_directories` | List allowed directories | - |
+
+### Search and Info
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_filesystem_search_files` | Search for files matching pattern | `path`, `pattern`, `excludePatterns` (optional) |
+| `mcp_filesystem_get_file_info` | Get metadata about a file | `path` |
+
+## Web Access Tools
+
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| `mcp_fetch_fetch` | Fetch content from a URL | `url`, `max_length` (optional), `raw` (optional), `start_index` (optional) |
+
+## Usage Examples
+
+### Creating a Branch and Adding Files
+
+```javascript
+// Create a new branch
+mcp_github_create_branch({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  branch: "feature/new-component",
+  from_branch: "develop"
+});
+
+// Add files to the branch
+mcp_github_push_files({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  branch: "feature/new-component",
+  message: "feat: Add new component implementation",
+  files: [
+    {
+      path: "app/components/new_component.py",
+      content: "# New component implementation\n\nclass NewComponent:\n    def __init__(self):\n        pass"
+    },
+    {
+      path: "tests/components/test_new_component.py",
+      content: "# Tests for new component\n\nimport pytest\n\ndef test_new_component():\n    assert True"
+    }
+  ]
+});
+```
+
+### Creating a Pull Request
+
+```javascript
+mcp_github_create_pull_request({
+  owner: "jdamboeck",
+  repo: "preview-maker",
+  title: "feat: Add new component implementation",
+  body: "This PR adds the new component with tests.\n\nCloses #42",
+  head: "feature/new-component",
+  base: "develop"
+});
+```
+
+### Working with Docker
+
+```javascript
+// List all containers
+mcp_docker_list_containers({
+  random_string: "any_value"
+});
+
+// Get logs from a container
+mcp_docker_get_logs({
+  container_name: "preview-maker-test-1"
+});
+```
+
+### File Operations
+
+```javascript
+// Create a directory
+mcp_filesystem_create_directory({
+  path: "/home/jd/dev/projects/preview-maker/app/new_module"
+});
+
+// Write a file
+mcp_filesystem_write_file({
+  path: "/home/jd/dev/projects/preview-maker/app/new_module/component.py",
+  content: "# New component implementation\n\nclass NewComponent:\n    def __init__(self):\n        pass"
+});
+
+// Search for files
+mcp_filesystem_search_files({
+  path: "/home/jd/dev/projects/preview-maker",
+  pattern: "test_*.py",
+  excludePatterns: ["__pycache__"]
+});
+```
+
+## Best Practices
+
+1. **Prefer MCP Tools**: Use MCP tools instead of direct terminal commands when possible
+2. **Error Handling**: Always check for errors in the response
+3. **Atomicity**: For GitHub operations, try to use atomic operations (like `push_files` for multiple files)
+4. **Permissions**: Be aware of allowed directories for filesystem operations
+5. **Documentation**: Document any MCP tool usage in commit messages or PR descriptions
+
+## Limitations
+
+1. MCP tools only work within allowed directories
+2. Some advanced Git operations may still require GitHub CLI
+3. For complex Docker operations, you may need to use Docker CLI through terminal commands

--- a/rebuild_plan/agent_shortterm_memory.md
+++ b/rebuild_plan/agent_shortterm_memory.md
@@ -6,6 +6,7 @@ This document serves as a compact reference for agents working on the Preview Ma
 - **Repository**: [GitHub.com/jdamboeck/preview-maker](https://github.com/jdamboeck/preview-maker)
 - **Structure**: Transitioning from monolithic to component-based architecture
 - **Key Technologies**: Python 3.8+, GTK 4.0, Pillow, Cairo, Gemini AI, Docker
+- **Available Tools**: [MCP Tools Reference](../docs/mcp_tools_reference.md) for GitHub, Docker and filesystem operations
 
 ## Development Cycle
 
@@ -25,10 +26,34 @@ This document serves as a compact reference for agents working on the Preview Ma
   - [GTK Development Guide](00_prerequisites/04_gtk_development_guide.md) (for UI tasks)
   - [Gemini AI Integration](00_prerequisites/05_gemini_ai_integration.md) (for AI features)
 
-### 3. Check Git Workflow and create branch
+### 3. Create Branch Using GitHub CLI
 - Work in feature branches branched from `develop`
 - Branch naming: `feature/<feature-name>`, `bugfix/<bug-description>`
-- **Resources**: [Git Workflow](git_workflow.md)
+- **With GitHub CLI**:
+  ```bash
+  # Create feature branch from develop
+  gh api repos/jdamboeck/preview-maker/git/refs -f ref="refs/heads/feature/new-feature" \
+    -f sha="$(gh api repos/jdamboeck/preview-maker/git/refs/heads/develop --jq '.object.sha')"
+  # Check out the branch locally
+  gh repo clone jdamboeck/preview-maker --branch feature/new-feature
+  # OR if you've already cloned the repo
+  gh repo sync
+  gh checkout feature/new-feature
+  ```
+- **With MCP Functions**:
+  ```javascript
+  // Create branch from develop
+  mcp_github_create_branch({
+    owner: "jdamboeck",
+    repo: "preview-maker",
+    branch: "feature/new-feature",
+    from_branch: "develop"
+  });
+  ```
+- **Resources**:
+  - [Git Workflow](git_workflow.md)
+  - [GitHub CLI Guide](../docs/github_cli_guide.md)
+  - [MCP Tools Reference](../docs/mcp_tools_reference.md)
 
 ### 4. Formulate Plan
 - Define approach based on component architecture
@@ -76,23 +101,70 @@ This document serves as a compact reference for agents working on the Preview Ma
 - Mark completed components in progress tracking
 - **Resource**: [Progress Tracking](progress_tracking.md)
 
-### 10. Commit and Push
+### 10. Commit Changes
 - Follow commit message conventions: `feat:`, `fix:`, `docs:`, etc.
 - Keep first line under 50 characters
-- Push to feature branch
-- **Example**:
+- **With MCP Functions**:
+  ```javascript
+  // Update file via MCP
+  mcp_github_create_or_update_file({
+    owner: "jdamboeck",
+    repo: "preview-maker",
+    path: "path/to/file.py",
+    message: "feat: Add circular mask generation",
+    content: "encoded_file_content",
+    branch: "feature/circular-mask"
+  });
+
+  // For multiple files, use push_files instead
+  mcp_github_push_files({
+    owner: "jdamboeck",
+    repo: "preview-maker",
+    branch: "feature/circular-mask",
+    message: "feat: Add circular mask generation",
+    files: [
+      {
+        path: "path/to/file1.py",
+        content: "file1_content"
+      },
+      {
+        path: "path/to/file2.py",
+        content: "file2_content"
+      }
+    ]
+  });
+  ```
+- **With GitHub CLI** (if local changes need to be committed):
   ```bash
-  git add .
-  git commit -m "feat: Add circular mask generation"
-  git push origin feature/circular-mask
+  # Stage and commit changes through GitHub CLI
+  gh api --method POST /repos/jdamboeck/preview-maker/git/commits \
+    -f message="feat: Add circular mask generation" \
+    -f tree="[tree_sha]" \
+    -f parent="[parent_sha]"
+  # Note: This is simplified and would require additional steps to get tree_sha
+  # Consider using gh workflow to run a GitHub Action for file commits instead
   ```
 
 ### 11. Create Pull Request
-- PR to `develop` branch
+- Use GitHub CLI to create PR to `develop` branch
 - Ensure tests pass in CI
 - Reference any related issues
-- Use Github Cli to create
-
+- **With GitHub CLI**:
+  ```bash
+  gh pr create --base develop --title "feat: Add circular mask generation" \
+    --body "Implements algorithm for creating circular masks with adjustable parameters. Closes #123"
+  ```
+- **With MCP Functions**:
+  ```javascript
+  mcp_github_create_pull_request({
+    owner: "jdamboeck",
+    repo: "preview-maker",
+    title: "feat: Add circular mask generation",
+    body: "Implements algorithm for creating circular masks. Closes #123",
+    head: "feature/circular-mask",
+    base: "develop"
+  });
+  ```
 
 ### 12. Plan Next Task
 - Consult progress tracking for next task
@@ -118,6 +190,29 @@ This document serves as a compact reference for agents working on the Preview Ma
 - Google docstring format
 - Keep README.md files current
 - Use "docs:" prefix for documentation commits
+
+### GitHub CLI Usage
+- Always use GitHub CLI (`gh`) or MCP GitHub functions for repository operations
+- Avoid direct Git commands
+- Check [GitHub CLI Guide](../docs/github_cli_guide.md) for commands
+- See complete [MCP Tools Reference](../docs/mcp_tools_reference.md) for all available MCP functions
+- Key operations:
+  ```bash
+  # List pull requests
+  gh pr list
+
+  # Check PR status
+  gh pr checks
+
+  # Merge PR with branch deletion
+  gh pr merge --merge --delete-branch
+
+  # View repository status
+  gh repo view
+
+  # Sync repository
+  gh repo sync
+  ```
 
 ### Docker Tips
 - Always use `--rm` flag

--- a/rebuild_plan/progress_tracking.md
+++ b/rebuild_plan/progress_tracking.md
@@ -100,7 +100,7 @@ This document tracks the progress of the Preview Maker rebuild implementation. U
 | Developer Guide | Not Started | - |
 | Architecture Overview | In Progress | Component dependency diagram implemented |
 | Installation Guide | Completed | Added to README.md |
-| Git Workflow | Completed | Added git_workflow.md with comprehensive workflow |
+| Git Workflow | Completed | Added git_workflow.md with comprehensive workflow, GitHub CLI guide, PR/Issue templates, and branch protection documentation |
 | Testing Guide | Completed | Added comprehensive Xwayland testing documentation, X11 forwarding guide, and testing integration documentation |
 
 ## Milestones


### PR DESCRIPTION
This PR adds comprehensive documentation for MCP tools and enhances GitHub CLI workflow guidance.\n\n- Create comprehensive MCP tools reference documentation\n- Update agent memory with GitHub CLI and MCP examples\n- Add GitHub CLI recommendation to .cursorrules\n- Replace Git commands with GitHub CLI alternatives